### PR TITLE
Update libfq.c – remove apparently unused variable "double_output"

### DIFF
--- a/src/libfq.c
+++ b/src/libfq.c
@@ -3835,9 +3835,6 @@ _FQformatDatum(FBconn *conn, FQresTupleAttDesc *att_desc, XSQLVAR *var)
 			short 	 dscale = var->sqlscale;
 			unsigned rounded = 0;
 
-			FQExpBufferData double_output;
-			initFQExpBuffer(&double_output);
-
 
 			/* NaN, Infinity or -Infinity */
 			if (_FQcheckSpecialValue(format_buffer, length, value, &s))


### PR DESCRIPTION
Does not seem to be used anywhere (and it leaks memory due to the `malloc()` inside that apparently nowhere gets `free()`d?)